### PR TITLE
Return all comments if no target is specified, fixes #25

### DIFF
--- a/config-sample.json
+++ b/config-sample.json
@@ -11,7 +11,8 @@
         "service_url": "https://server.tld/comments",
         "token_sender": "comments@server.tld",
         "token_recipients": "admin@server.tld, moderator@server.tld",
-        "retention_days": 14
+        "retention_days": 14,
+        "limit": 200
     },
     "suggest": {
         "owner": "datenanfragen",

--- a/src/handlers/comments/getComments.js
+++ b/src/handlers/comments/getComments.js
@@ -1,10 +1,9 @@
 const config = require('../../../config.json');
 async function getComments(request, h) {
-    const where_clause = { is_accepted: true, ...(request.params.target && { target: request.params.target }) };
     return await request.server.methods
         .knex('comments')
         .select()
-        .where(where_clause)
+        .where({ is_accepted: true, ...(request.params.target && { target: request.params.target }) })
         .limit(request.params.target ? config.comments.limit : Number.MAX_SAFE_INTEGER)
         .then((data) =>
             data.map((item) => {
@@ -38,11 +37,10 @@ function atomFeedForItems(items, target) {
     );
 
     // Excerpt regex taken from https://stackoverflow.com/a/5454297
+    const excerpt = (str) => str.replace(/\s+/g, ' ').replace(/^(.{40}[^\s]*).*/, '$1');
     const entries = items.map(
         (item) => `    <entry>
-        <title>${!target ? item.target + ':' : ''}${item.message
-            .replace(/\s+/g, ' ')
-            .replace(/^(.{40}[^\s]*).*/, '$1')}</title>
+        <title>${!target ? item.target + ': ' : ''}${excerpt(item.message)}</title>
         <id>datenanfragenDE:${item.target}:comment:${item.id}</id>
         <updated>${item.added_at}</updated>
         <author><name>${item.author}</name></author>

--- a/src/handlers/comments/getComments.js
+++ b/src/handlers/comments/getComments.js
@@ -1,12 +1,11 @@
 const config = require('../../../config.json');
 async function getComments(request, h) {
-    let where_clause = { is_accepted: true };
-    if (request.params.target) where_clause.target = request.params.target;
+    const where_clause = { is_accepted: true, ...(request.params.target && { target: request.params.target }) };
     return await request.server.methods
         .knex('comments')
         .select()
         .where(where_clause)
-        .limit(config.comments.limit)
+        .limit(request.params.target ? config.comments.limit : Number.MAX_SAFE_INTEGER)
         .then((data) =>
             data.map((item) => {
                 try {
@@ -44,7 +43,7 @@ function atomFeedForItems(items, target) {
         <title>${!target ? item.target + ':' : ''}${item.message
             .replace(/\s+/g, ' ')
             .replace(/^(.{40}[^\s]*).*/, '$1')}</title>
-        <id>datenanfragenDE:${target}:comment:${item.id}</id>
+        <id>datenanfragenDE:${item.target}:comment:${item.id}</id>
         <updated>${item.added_at}</updated>
         <author><name>${item.author}</name></author>
         <content type="text">${item.message}</content>

--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,7 @@ const init = async () => {
             validate: {
                 params: Joi.object({
                     action: Joi.string().valid('get', 'feed').required(),
-                    target: Joi.string().required(),
+                    target: Joi.string(),
                 }),
             },
         },


### PR DESCRIPTION
* returns all comments if no target is specified, i.e. on `/comments/[get|feed]`
* **new**: limit amount of returned comments to value specified in `config`