### PR TITLE
Comments: specify select

### DIFF
--- a/src/handlers/comments/getComments.js
+++ b/src/handlers/comments/getComments.js
@@ -2,7 +2,7 @@ const config = require('../../../config.json');
 async function getComments(request, h) {
     return await request.server.methods
         .knex('comments')
-        .select()
+        .select('id', 'author', 'message', 'target', 'additional', 'added_at')
         .where({ is_accepted: true, ...(request.params.target && { target: request.params.target }) })
         .limit(request.params.target ? Number.MAX_SAFE_INTEGER : config.comments.limit)
         .then((data) =>


### PR DESCRIPTION
This saves us some entropy-rich (kilo)bytes and is cleaner imo. By explicitely setting what we want to return, it's less likely to return too much if we change something in the future. :D

I've tested this with 110 short comments and this saved me ~5KB (uncompressed) presumably by not serving `accept_token`. Besides that I see no reason why we should return it in the first place. :D 

I would really like to do something similiar for the `id` but it seems like the frontend needs it atm.