### PR TITLE
Increase timeout for donation APIs

### DIFF
--- a/src/handlers/donation/apis.js
+++ b/src/handlers/donation/apis.js
@@ -3,7 +3,7 @@ const config = require('../../../config.json');
 
 const mollie = axios.create({
     baseURL: config.donation.mollie.endpoint,
-    timeout: 1000,
+    timeout: 5000,
     headers: {
         Authorization: 'Bearer ' + config.donation.mollie.api_key,
         'Content-Type': 'application/json',
@@ -12,7 +12,7 @@ const mollie = axios.create({
 
 const coingate = axios.create({
     baseURL: config.donation.coingate.endpoint,
-    timeout: 1000,
+    timeout: 5000,
     headers: {
         Authorization: 'Token ' + config.donation.coingate.api_key,
         'Content-Type': 'application/json',


### PR DESCRIPTION
I just tested making a cryptocurrency donation and received an "invalid response from payment provider" error modal. This only happens intermittently.

The logs show that this is due to the timeout:

```
14:22:27 0|backend  | Error: timeout of 1000ms exceeded
```
