### PR TITLE
Comments: Also strip tags from body

### DIFF
--- a/src/handlers/comments/getComments.js
+++ b/src/handlers/comments/getComments.js
@@ -47,7 +47,7 @@ function atomFeedForItems(items, target) {
         <id>datenanfragenDE:${item.target}:comment:${item.id}</id>
         <updated>${item.added_at}</updated>
         <author><name>${item.author}</name></author>
-        <content type="text">${item.message}</content>
+        <content type="text">${stripTags(item.message)}</content>
     </entry>`
     );
 


### PR DESCRIPTION
Even with the changes from #39, we are still not producing a valid
feed since XML doesn't recognize our custom elements as valid.

This commit thus also strips the tags from the message body. It
would be nicer to transform them to valid HTML but that would also
require making sure no evil HTML is emitted in the feed and I don't
feel like implementing that right now. This works for now.