### PR TITLE
refactor: Fix of urlencode for handler.js

### DIFF
--- a/src/handlers/suggest/handler.js
+++ b/src/handlers/suggest/handler.js
@@ -54,7 +54,7 @@ async function suggest(request, h) {
                             pull_number: pr.data.number,
                             body: `This suggestion was submitted through the website.
 
-**[Edit](https://company-json.datenanfragen.de/#!doc=${encodeURIComponent(JSON.stringify(company))}\n)**`,
+**[Edit](https://company-json.datenanfragen.de/#!doc=${encodeURIComponent(JSON.stringify(company))} )**`,
                             maintainer_can_modify: true, // We cannot set this setting through the plugin, but because it is just a gimmick, we can do it afterwards just as well.
                         })
                     )


### PR DESCRIPTION
Fixes #28 

The issue was that the ')' at the end was considered to be a part of the URL. Adding a new line between the URL and last ')' makes the Markdown and link to function properly.