### PR TITLE
Stop the most obvious comment spam by introducing length limits

### DIFF
--- a/src/handlers/comments/putComment.js
+++ b/src/handlers/comments/putComment.js
@@ -3,7 +3,13 @@ const nodemailer = require('nodemailer');
 const config = require('../../../config.json');
 const { stripTags } = require('../../util/functions');
 
+const successMessage =
+    'Successfully added comment. It will need to be accepted by an administrator before it is published.';
+
 async function putComment(request, h) {
+    // Silently drop ridiculously short comments, which are pretty much guaranteed to be spam.
+    if (request.payload.message?.length < 5) return { message: successMessage };
+
     const service_url =
         config.comments.service_url || `${request.headers['X-Forwarded-Proto']}://${request.headers['Host']}/comments`;
 
@@ -23,8 +29,7 @@ async function putComment(request, h) {
         .insert(item)
         .then(() => sendTokenMail(item, service_url))
         .then(() => ({
-            message:
-                'Successfully added comment. It will need to be accepted by an administrator before it is published.',
+            message: successMessage,
         }))
         .catch((e) => {
             console.error(e);

--- a/src/index.js
+++ b/src/index.js
@@ -71,9 +71,9 @@ const init = async () => {
         options: {
             validate: {
                 payload: Joi.object({
-                    author: Joi.string().allow(''),
-                    message: Joi.string().required(),
-                    target: Joi.string().required(),
+                    author: Joi.string().max(75).allow(''),
+                    message: Joi.string().max(10000).required(),
+                    target: Joi.string().max(150).required(),
                     additional: Joi.object(),
                 }),
             },

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ const init = async () => {
                 payload: Joi.object({
                     author: Joi.string().max(75).allow(''),
                     message: Joi.string().max(10000).required(),
-                    target: Joi.string().max(150).required()
+                    target: Joi.string().max(150).required(),
                 }),
             },
         },


### PR DESCRIPTION
This was bound to happen at some point. *sigh* Though I am actually surprised at how long we got away with having no spam protection at all, so that's something least.